### PR TITLE
add parameter to handle svg aspect ratio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "requires": {
         "ajv": "5.5.2",
         "chokidar": "1.7.0",
-        "rxjs": "5.5.6",
+        "rxjs": "5.5.7",
         "source-map": "0.5.7"
       },
       "dependencies": {
@@ -49,7 +49,7 @@
       "dev": true,
       "requires": {
         "@ngtools/json-schema": "1.2.0",
-        "rxjs": "5.5.6"
+        "rxjs": "5.5.7"
       }
     },
     "@angular/animations": {
@@ -117,7 +117,7 @@
         "postcss-url": "7.3.1",
         "raw-loader": "0.5.1",
         "resolve": "1.5.0",
-        "rxjs": "5.5.6",
+        "rxjs": "5.5.7",
         "sass-loader": "6.0.7",
         "semver": "5.5.0",
         "silent-error": "1.1.0",
@@ -283,7 +283,7 @@
       "integrity": "sha512-7aVP4994Hu8vRdTTohXkfGWEwLhrdNP3EZnWyBootm5zshWqlQojUGweZe5zwewsKcixeVOiy2YtW+aI4aGSLA==",
       "dev": true,
       "requires": {
-        "rxjs": "5.5.6",
+        "rxjs": "5.5.7",
         "semver": "5.5.0",
         "semver-intersect": "1.3.1"
       }
@@ -300,7 +300,7 @@
       "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.4.7"
       }
     },
     "@types/glob": {
@@ -311,7 +311,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.6"
+        "@types/node": "9.4.7"
       }
     },
     "@types/jasmine": {
@@ -354,7 +354,7 @@
       "dev": true,
       "requires": {
         "@types/glob": "5.0.35",
-        "@types/node": "9.4.6"
+        "@types/node": "9.4.7"
       }
     },
     "@types/selenium-webdriver": {
@@ -7709,7 +7709,7 @@
         "rollup-plugin-commonjs": "8.3.0",
         "rollup-plugin-license": "0.6.0",
         "rollup-plugin-node-resolve": "3.2.0",
-        "rxjs": "5.5.6",
+        "rxjs": "5.5.7",
         "sorcery": "0.10.0",
         "strip-bom": "3.0.0",
         "stylus": "0.54.5",

--- a/src/lib/trend/trend.component.ts
+++ b/src/lib/trend/trend.component.ts
@@ -30,6 +30,7 @@ import { normalizeDataset } from './trend.helpers';
     [attr.stroke-width]="strokeWidth"
     [attr.stroke-linecap]="strokeLinecap"
     [attr.viewBox]="viewBox"
+    [attr.preserveAspectRatio]="preserveAspectRatio"
   >
     <defs *ngIf="gradient && gradient.length">
       <linearGradient [attr.id]="gradientId"
@@ -103,6 +104,7 @@ export class TrendComponent implements OnChanges {
   @Input() strokeLinecap = '';
   @Input() strokeWidth = 1;
   @Input() gradient: string[] = [];
+  @Input() preserveAspectRatio: string;
   @ViewChild('pathEl') pathEl: ElementRef;
   gradientTrimmed: any[];
   d: any;


### PR DESCRIPTION
In some case it is interesting to be able to control svg aspect ratio
Using ngx-trend as such:
` <ngx-trend autoDraw="true" autoDrawDuration="3000" autoDrawEasing="ease-out"      smooth="true" 
      preserveAspectRatio="none" height="100"
[data]="placeholderData" [gradient]="gradient" [radius]="radius" [strokeWidth]="strokeWidth"[strokeLinecap]="strokeLinecap">` 
allows to address some scenarios where the default 1:4 ratio would not fit in wide screen
